### PR TITLE
create reply comment function and fix ui bug

### DIFF
--- a/app/assets/stylesheets/_article.scss
+++ b/app/assets/stylesheets/_article.scss
@@ -371,9 +371,8 @@
 .comment-item {
   display: flex;
   flex-direction: column;
-  gap: 15px;
+  gap: 10px;
   padding: 15px 0;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
 }
 
 .comment-item:last-child {
@@ -506,4 +505,51 @@
 
 .view-details-button:hover {
   text-decoration: underline;
+}
+
+.reply-form {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+}
+
+.reply-comment::before {
+  content: "⤷";
+  display: inline-block;
+  margin-right: 6px;
+  color: #888;
+}
+
+.reply-item {
+  display: flex;
+}
+
+.reply-avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid rgba(102, 126, 234, 0.1);
+  flex-shrink: 0;
+}
+
+.reply-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.reply-header a {
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: #1f2937;
+  text-decoration: none;
+  margin-bottom: 0;
+}
+
+.reply-actions {
+  display: flex;
+  gap: 15px;
 }

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,9 +1,18 @@
 module Api::V1
   class ApiController < ApplicationController
+    include CanCan::ControllerAdditions
+
     skip_before_action :verify_authenticity_token
     skip_before_action :set_ransack_query
     before_action :authenticate
     before_action :initialize_api_ransack_query
+
+    attr_reader :current_user
+
+    rescue_from CanCan::AccessDenied do
+      render json: {status: :error, message: Settings.msg.action_not_allowed},
+             status: :forbidden
+    end
 
     private
     def authenticate

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -47,6 +47,7 @@ module Api::V1
     end
 
     def update
+      authorize! :modify, @article
       if @article.update(article_params)
         render json: {data: @article, status: :success}, status: :ok
       else
@@ -56,6 +57,7 @@ module Api::V1
     end
 
     def destroy
+      authorize! :modify, @article
       @article.destroy
       render json: {message: Settings.msg.article_deleted}, status: :ok
     end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -5,6 +5,7 @@ class ArticlesController < ApplicationController
   def show
     @comment = Comment.new
     @comments = @article.comments.includes(user: {avatar_attachment: :blob})
+                        .first_level
   end
 
   def edit; end
@@ -54,7 +55,7 @@ class ArticlesController < ApplicationController
       respond_to do |format|
         format.html do
           redirect_to profile_path(current_user), status: :see_other,
-notice: t("msg.delete_article_success")
+                      notice: t("msg.delete_article_success")
         end
         format.json{head :no_content}
       end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -54,6 +54,30 @@ class CommentsController < ApplicationController
     end
   end
 
+  def new_reply
+    @new_comment = @article.comments.build(parent_id: @comment.id)
+
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+
+  def create_reply
+    @new_comment = @article.comments.build(comment_params)
+    @new_comment.user = current_user
+    @new_comment.parent_id = @comment.id
+
+    if @new_comment.save
+      respond_to do |format|
+        format.turbo_stream
+        format.html{redirect_to article_path(@article)}
+      end
+    else
+      flash[:alert] = t "msg.reply_failed"
+      redirect_to article_path(@article)
+    end
+  end
+
   private
   def comment_params
     params.require(:comment).permit(Comment::PERMIT_PARAMS)

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -24,7 +24,6 @@ class RelationshipsController < ApplicationController
       flash[:alert] = t("msg.permission_denied")
       return redirect_to root_path
     end
-
     @user = @relationship.followed
     current_user.unfollow(@user)
     respond_to do |format|

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -11,6 +11,8 @@ class Ability
     can :create, Article
     can :modify, Article, user_id: user.id
     can :create, Comment
+    can :new_reply, Comment
+    can :create_reply, Comment
     can :modify, Comment, user_id: user.id
     can :create, Relationship, follower_id: user.id
     can :destroy, Relationship, follower_id: user.id

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,6 +1,19 @@
 class Comment < ApplicationRecord
-  PERMIT_PARAMS = %i(content article_id).freeze
+  PERMIT_PARAMS = %i(content article_id parent_id).freeze
 
   belongs_to :user
   belongs_to :article
+  belongs_to :parent, class_name: "Comment", optional: true
+  has_many :replies, class_name: "Comment", foreign_key: "parent_id",
+            dependent: :destroy
+
+  validates :content, presence: true, length: {maximum: 500}
+
+  scope :first_level, ->{where(parent_id: nil)}
+
+  def limit_depth_to_two_levels
+    return unless parent.present? && parent.parent.present?
+
+    errors.add(:base, "Comments can only be nested one level deep.")
+  end
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -11,19 +11,22 @@
           <%= link_to comment.user.username, profile_path(comment.user), class: "comment-author" %>
           <small class="comment-time"><%= time_ago_in_words(comment.created_at) %> <%= t "common.ago" %> </small>
         </div>
-        <% if comment.user == current_user %>
-          <div class="comment-actions">
-            <%= link_to edit_article_comment_path(comment.article,comment), 
-              data: { turbo_frame: "comment_form_#{comment.id}" }, class: "text-primary" do %>
-              <%= bootstrap_icon "pencil" %>
-              <%= t "common.edit" %>
+        <% if user_signed_in? %>
+          <div class="reply-actions">
+            <%= link_to new_reply_article_comment_path(comment.article, comment), data: { turbo_stream: true, turbo_frame: "_self" }, class: "text-secondary" do %>
+              <%= bootstrap_icon "reply" %>
             <% end %>
+            <% if comment.user == current_user %>
+              <%= link_to edit_article_comment_path(comment.article,comment), 
+                data: { turbo_frame: "comment_form_#{comment.id}" }, class: "text-primary" do %>
+                <%= bootstrap_icon "pencil" %>
+              <% end %>
 
-            <%= link_to article_comment_path(comment.article, comment),
-              data: { turbo_method: :delete, turbo_confirm: t("msg.you_sure") },
-              class: "text-danger" do %>
-              <%= bootstrap_icon "trash3" %>
-              <%= t "common.delete" %>
+              <%= link_to article_comment_path(comment.article, comment),
+                data: { turbo_method: :delete, turbo_confirm: t("msg.you_sure") },
+                class: "text-danger" do %>
+                <%= bootstrap_icon "trash3" %>
+              <% end %>
             <% end %>
           </div>
         <% end %>
@@ -32,3 +35,6 @@
     <p><%= comment.content %></p>
   </div>
 <% end %>
+<div id="replies_<%= comment.id %>" class="ms-5">
+    <%= render partial: "comments/reply", collection: comment.replies, as: :comment %>
+</div>

--- a/app/views/comments/_reply.html.erb
+++ b/app/views/comments/_reply.html.erb
@@ -1,0 +1,30 @@
+<%= turbo_frame_tag "comment_form_#{comment.id}" do %>
+  <div class="reply-item reply-comment">
+    <% if comment.user.present? %>
+      <div class="reply-header">
+        <% if comment.user.avatar.attached? %>
+          <%= image_tag comment.user.avatar, class: "reply-avatar", alt: "#{comment.user.username}'s avatar" %>
+        <% else %>
+          <%= image_tag Settings.default_avatar, class: "reply-avatar", alt: "Default avatar" %>
+        <% end %>
+        <%= link_to comment.user.username, profile_path(comment.user), class: "comment-author" %>
+        <small class="comment-time"><%= time_ago_in_words(comment.created_at) %> <%= t "common.ago" %></small>
+        <% if comment.user == current_user %>
+          <div class="reply-actions">
+            <%= link_to edit_article_comment_path(comment.article,comment), 
+              data: { turbo_frame: "comment_form_#{comment.id}" }, class: "text-primary" do %>
+              <%= bootstrap_icon "pencil" %>
+            <% end %>
+
+            <%= link_to article_comment_path(comment.article, comment),
+              data: { turbo_method: :delete, turbo_confirm: t("msg.you_sure") },
+              class: "text-danger" do %>
+              <%= bootstrap_icon "trash3" %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+    <p class="ms-5"><%= comment.content %></p>
+<% end %>

--- a/app/views/comments/_reply_form.html.erb
+++ b/app/views/comments/_reply_form.html.erb
@@ -1,0 +1,18 @@
+<div id="reply_form_<%= @comment.id %>">
+  <div class="d-flex align-items-center gap-2 mt-3 reply-comment">
+    <% if @article.user.avatar.attached? %>
+      <%= image_tag @article.user.avatar, class: "author-avatar", alt: "#{@article.user.username}'s avatar" %>
+    <% else %>
+      <%= image_tag Settings.default_avatar, class: "author-avatar", alt: "Default avatar" %>
+    <% end %>
+
+    <%= form_with(model: [@article, @new_comment], url: create_reply_article_comment_path(@article, @comment), class: "reply-form") do |form| %>
+      <%= form.hidden_field :parent_id, value: @comment.id %>
+      <%= form.text_field :content, placeholder: t("comment.reply_placeholder"), rows: 3, class: "form-control flex-grow-1" %>
+
+      <div>
+        <%= form.submit t("comment.reply_btn"), class: "btn btn-sm btn-primary" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/comments/create_reply.turbo_stream.erb
+++ b/app/views/comments/create_reply.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.remove "reply_form_#{@comment.id}" %>
+
+<%= turbo_stream.append "replies_#{@comment.id}" do %>
+  <%= render partial: "comments/reply", locals: { comment: @new_comment } %>
+<% end %>

--- a/app/views/comments/new_reply.turbo_stream.erb
+++ b/app/views/comments/new_reply.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.append "replies_#{@comment.id}" do %>
+  <%= render partial: "comments/reply_form" %>
+<% end %>

--- a/app/views/comments/update.turbo_stream.erb
+++ b/app/views/comments/update.turbo_stream.erb
@@ -1,3 +1,7 @@
 <%= turbo_stream.replace "comment_form_#{@comment.id}" do %>
-  <%= render @comment %>
+  <% if @comment.parent.present? %>
+    <%= render partial: "comments/reply", locals: { comment: @comment } %>
+  <% else %>
+    <%= render @comment %>
+  <% end %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,12 +25,19 @@
   <body>
     
     <%= render "shared/header" %>
-    <div class="container-fluid mt-5">
-      <p class="alert notice"><%= notice %></p>
-      <p class="alert"><%= alert %></p>
-    </div>
-    <div class="container">
-      <%= yield %>
+    <div class="mt-5 pt-5">
+      <div class="container-fluid">
+        <% if notice.present? %>
+          <p class="alert alert-info"><%= notice %></p>
+        <% end %>
+
+        <% if alert.present? %>
+          <p class="alert alert-danger"><%= alert %></p>
+        <% end %>
+      </div>
+      <div class="container">
+        <%= yield %>
+      </div>
     </div>
   </body>
 </html>

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, @user.username %>
 <%= render "profile_header" %>
 
 <div class="main-content">
@@ -25,7 +26,7 @@
             <div class="info-item">
                 <%= bootstrap_icon "cake", height: Settings.default.view.edit_profile.icon_size %>
                 <span class="info-label"><%= t ".birthday" %>:</span>
-                <span class="info-value"><%= @user.date_of_birth.strftime("%B %d, %Y") %></span>
+                <span class="info-value"><%= l @user.date_of_birth, format: "%B %d, %Y" %></span>
             </div>
         <% end %>
     </div>
@@ -42,7 +43,12 @@
         </div>
     <% end %>
     <% if @user == current_user %>
-        <%= link_to t("common.edit"), edit_user_registration_path, class: "btn btn-primary" %>
+      <div class="d-flex justify-content-center">
+        <%= link_to edit_user_registration_path, class: "btn btn-primary" do %>
+          <%= bootstrap_icon "pencil-square", height: Settings.default.view.edit_profile.icon_size %>
+          <span><%= t "common.edit" %></span>
+        <% end %>
+      </div>
     <% end %>
   </div>
   <div>
@@ -53,7 +59,7 @@
       <% if @user.articles.any? %>
         <%= render partial:"shared/article_card", collection: @user.articles, as: :article %>
       <% else %>
-        <p><%= t ".no_articles" %></p>
+        <p class="text-center"><%= t ".no_articles" %></p>
       <% end %>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -16,41 +16,16 @@
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav">
           <li class="nav-item">
-            <%= link_to t("header.home"), root_path, class: "nav-link" %>
+            <%= link_to profiles_path, class: "nav-link" do %>
+              <%= bootstrap_icon "people-fill", height: Settings.default.view.edit_profile.icon_size %>
+              <span><%= t "header.profiles" %></span>
+            <% end %>
           </li>
-          <li class="nav-item">
-            <%= link_to t("header.profiles"), profiles_path, class: "nav-link" %>
-          </li>
-          <li class="nav-item">
-            <%= link_to t('header.profiles'), profiles_path, class: "nav-link" %>
-          </li>
-          <li class="nav-item">
-            <%= link_to t('header.profiles'), profiles_path, class: "nav-link" %>
-          </li>
-          <% if user_signed_in? %>
-            <li class="nav-item">
-              <%= link_to t("header.profile"), profile_path(current_user), class: "nav-link" %>
-            </li>
-            <li class="nav-item">
-              <%= link_to t("header.logout"), destroy_user_session_path, 
-                data: { turbo_method: :delete, turbo_confirm: t("msg.you_sure") }, class: "nav-link" %>
-            </li>
-          <% else %>
-            <li class="nav-item">
-              <%= link_to t("header.login"), new_user_session_path, class: "nav-link" %>
-            </li>
-            <li class="nav-item">
-               <%= link_to t("header.sign_up"), new_user_registration_path, class: "nav-link" %>
-            </li>
-          <% end %>
         </ul>
         <%= render "shared/search_form" %>
 
-        <% if user_signed_in? %>
-          <%= render "shared/notification_list" %>
-        <% end %>
-        <ul class="navbar-nav ms-auto">
-          <li class="nav-item dropdown">
+        <ul class="navbar-nav ms-auto d-flex align-items-center gap-3">
+          <li class="nav-item dropdown me-5">
             <a 
               class="nav-link dropdown-toggle" 
               href="#" id="navbarDropdown" 
@@ -58,9 +33,10 @@
               data-bs-toggle="dropdown" 
               aria-expanded="false"
             >
+              <%= bootstrap_icon "globe", height: Settings.default.view.edit_profile.icon_size %>
               <%= I18n.locale == :en ? t("header.english") : t("header.vietnamese") %>
             </a>
-            <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+            <ul class="dropdown-menu shadow" aria-labelledby="navbarDropdown">
               <li>
                 <%= link_to t("header.english"), url_for(locale: :en), class: "dropdown-item" %>
               </li>
@@ -69,6 +45,49 @@
               </li>
             </ul>
           </li>
+          <% if user_signed_in? %>
+            <%= render "shared/notification_list" %>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle d-flex align-items-center gap-2 " href="#" id="navbarUserDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                <% if current_user.avatar.attached? && current_user.avatar.blob.persisted? %>
+                  <%= image_tag current_user.avatar, class: "author-avatar", alt: "#{current_user.username}'s avatar" %>
+                <% else %>
+                  <%= image_tag Settings.default_avatar, class: "author-avatar", alt: "Default avatar" %>
+                <% end %>
+                <%= current_user.username %>
+              </a>
+              <ul class="dropdown-menu dropdown-menu-end shadow" aria-labelledby="navbarUserDropdown">
+                <li>
+                  <%= link_to profile_path(current_user), class: "dropdown-item d-flex gap-2" do %>
+                    <%= bootstrap_icon "person-fill", height: Settings.default.view.edit_profile.icon_size %>
+                    <%= t("header.my_profile") %>
+                  <% end %>
+                </li>
+                <li><hr class="dropdown-divider"></li>
+                <li>
+                  <%= link_to destroy_user_session_path, 
+                    class: "dropdown-item text-danger d-flex gap-2", data: { turbo_method: :delete, turbo_confirm: t("msg.you_sure") } do %>
+                    <%= bootstrap_icon "box-arrow-right", height: Settings.default.view.edit_profile.icon_size %>
+                    <%= t("header.logout") %>
+                  <% end %>
+                </li>
+              </ul>
+            </li>
+          <% else %>
+            <li class="nav-item">
+              <%= link_to new_user_session_path, class: "nav-link d-flex align-items-center gap-2" do %>
+                <%= bootstrap_icon "box-arrow-in-right", height: Settings.default.view.edit_profile.icon_size %>
+                <span><%= t "header.login" %></span>
+              <% end %>
+            </li>
+            |
+            <li class="nav-item">
+               <%= link_to new_user_registration_path, class: "nav-link d-flex align-items-center gap-2" do %>
+                <%= bootstrap_icon "person-add", height: Settings.default.view.edit_profile.icon_size %>
+                <span><%= t "header.sign_up" %></span>
+              <% end %>
+            </li>
+          <% end %>
         </ul>
       </div>
     </div>

--- a/app/views/shared/_liked_user_list.html.erb
+++ b/app/views/shared/_liked_user_list.html.erb
@@ -12,7 +12,7 @@
         <%= render partial: "shared/user_item", collection: article.liked_users, as: :user %>
 
         <% if article.liked_users.empty? %>
-          <p class="text-muted"><%= t("common.no_likes_yet") %></p>
+          <p class="text-muted"><%= t("articles.no_likes_yet") %></p>
         <% end %>
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,9 +49,11 @@ en:
       address: "Address"
       birthday: "Birthday"
       about_me: "About Me"
+      no_articles: "This profile has no articles yet."
   articles:
     recently_updated: "Recently Updated"
     liked_user: "Liked Users"
+    no_likes_yet: "No likes yet."
     errors:
       one: "1 error prohibited this article from being saved:"
       other: "%{count} errors prohibited this article from being saved:"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -31,6 +31,7 @@ vi:
     logout: "Đăng xuất"
     sign_up: "Đăng ký"
     profiles: "Danh sách người dùng"
+    my_profile: "Hồ sơ của tôi"
     english: "Tiếng Anh"
     vietnamese: "Tiếng Việt"
     search_placehoder: "Tìm kiếm bài viết..."
@@ -75,9 +76,11 @@ vi:
       address: "Địa chỉ"
       birthday: "Ngày sinh"
       about_me: "Về tôi"
+      no_articles: "Hồ sơ này chưa có bài viết nào."
   articles:
     recently_updated: "Bài viết mới"
     liked_user: "Người thích bài viết"
+    no_likes_yet: "Chưa có ai thích bài viết này."
     errors:
       one: "1 lỗi đã ngăn không cho bài viết này được lưu:"
       other: "%{count} lỗi đã ngăn không cho bài viết này được lưu:"
@@ -89,6 +92,9 @@ vi:
       no_comments: "Chưa có bình luận nào. Hãy là người đầu tiên bình luận!"
       login_to_comment: "Vui lòng đăng nhập để để lại bình luận."
       no_article: "Hồ sơ này chưa có bài viết nào."
+  comment:
+    reply_placeholder: "Trả lời bình luận..."
+    reply_btn: "Trả lời"
   notification:
     no_notifications: "Không có thông báo"
     article_favorited: "Bài viết '%{article}' của bạn đã được yêu thích."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,12 @@ Rails.application.routes.draw do
       get "/following", to: "profile#following", as: "following"
     end
     resources :articles do
-      resources :comments, only: [ :create, :edit, :update, :destroy ]
+      resources :comments, only: [ :create, :edit, :update, :destroy ] do
+        member do
+          get :new_reply, to: "comments#new_reply"
+          post :create_reply, to: "comments#create_reply"
+        end
+      end
       resources :favorites, only: %i[create destroy]
     end
     scope "notifications" do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,3 +22,4 @@ msg:
   comment_deleted: "Comment deleted successfully"
   follow_success: "Followed successfully"
   unfollow_success: "Unfollowed successfully"
+  action_not_allowed: "You are not allowed to perform this action"

--- a/db/migrate/20250723083451_add_parent_id_to_comment.rb
+++ b/db/migrate/20250723083451_add_parent_id_to_comment.rb
@@ -1,0 +1,7 @@
+class AddParentIdToComment < ActiveRecord::Migration[6.0]
+  def change
+    add_column :comments, :parent_id, :bigint, null: true
+    add_index :comments, :parent_id
+    add_foreign_key :comments, :comments, column: :parent_id, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_22_162539) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_23_083451) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long
@@ -64,7 +64,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_22_162539) do
     t.bigint "article_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "parent_id"
     t.index ["article_id"], name: "index_comments_on_article_id"
+    t.index ["parent_id"], name: "index_comments_on_parent_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
@@ -124,6 +126,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_22_162539) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "articles", "users"
   add_foreign_key "comments", "articles"
+  add_foreign_key "comments", "comments", column: "parent_id", on_delete: :cascade
   add_foreign_key "comments", "users"
   add_foreign_key "favorites", "articles"
   add_foreign_key "favorites", "users"


### PR DESCRIPTION
## Related Tickets
- [#Task #89495](https://edu-redmine.sun-asterisk.vn/issues/89495)

## WHAT (optional)
- Thêm trường parent_id cho comment để tạo chức năng reply comment
- Bổ sung cancancan authorize cho các api sửa/xóa article
- Sửa lại 1 số lỗi ui

*Note: commit này em làm trước api, giờ em mới push
## HOW
- I edit js file, inject not_vary_normal items in calculate function.

## WHY (optional)
- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.

## Evidence (Screenshot or Video)
<img width="1093" height="784" alt="image" src="https://github.com/user-attachments/assets/5aac0d72-7c57-4393-9d13-ab611c2c7c9a" />
